### PR TITLE
Set view state on main thread, fix LoadMoreAdapter, fix State conflicts in ListViewModel

### DIFF
--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/BaseViewModel.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/BaseViewModel.kt
@@ -3,7 +3,9 @@ package com.duyp.architecture.clean.android.powergit.ui.base
 import android.arch.lifecycle.LifecycleOwner
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
+import android.support.annotation.MainThread
 import com.duyp.architecture.clean.android.powergit.postValueIfNew
+import com.duyp.architecture.clean.android.powergit.setValueIfNew
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
@@ -76,8 +78,9 @@ abstract class BaseViewModel<S, I> : ViewModel() {
      *
      * @param stateFunc provide new state by applying current state
      */
+    @MainThread
     protected fun setState(stateFunc: S.() -> S) {
-        state.postValueIfNew(stateFunc.invoke(state.value ?: initState()))
+        state.setValueIfNew(stateFunc.invoke(state.value ?: initState()))
     }
 
     /**

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/ListFragment.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/ListFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.support.v4.widget.SwipeRefreshLayout
 import android.support.v7.util.DiffUtil
 import android.support.v7.widget.RecyclerView
-import android.util.Log
 import android.view.View
 import com.duyp.architecture.clean.android.powergit.R
 import com.duyp.architecture.clean.android.powergit.event

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/ListFragment.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/ListFragment.kt
@@ -76,7 +76,9 @@ abstract class ListFragment<
 
         event(s.refresh) { refresh() }
 
-        event(s.loadCompleted) { onLoadCompleted(this) }
+        event(s.loadCompleted) { onLoadCompleted() }
+
+        event(s.dataUpdated) { onDataUpdated(this) }
 
         event(s.loadingMore) { onLoadingMore() }
 
@@ -110,15 +112,16 @@ abstract class ListFragment<
         mInfiniteScroller.reset()
     }
 
-    private fun onLoadCompleted(diffResult: DiffUtil.DiffResult) {
-        mInfiniteScroller.reset()
+    private fun onDataUpdated(diffResult: DiffUtil.DiffResult) {
         mAdapter.update(diffResult)
     }
 
+    private fun onLoadCompleted() {
+        mInfiniteScroller.reset()
+    }
+
     private fun setUiRefreshing(refreshing: Boolean) {
-//        Log.d("ListViewModel", "set refreshing: " + refreshing)
         refreshLayout?.post {
-//            Log.d("ListViewModel", "set refreshing done")
             refreshLayout?.isRefreshing = refreshing
         }
     }

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/ListFragment.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/ListFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.support.v4.widget.SwipeRefreshLayout
 import android.support.v7.util.DiffUtil
 import android.support.v7.widget.RecyclerView
+import android.util.Log
 import android.view.View
 import com.duyp.architecture.clean.android.powergit.R
 import com.duyp.architecture.clean.android.powergit.event
@@ -67,11 +68,11 @@ abstract class ListFragment<
      */
     protected fun onListStateUpdated(s: ListState) {
 
+        refreshLayout.isEnabled = s.refreshable
+
         setUiRefreshing(s.showLoading)
 
         updateEmptyView(s.showEmptyView)
-
-        refreshLayout.isEnabled = s.refreshable
 
         event(s.refresh) { refresh() }
 
@@ -115,7 +116,9 @@ abstract class ListFragment<
     }
 
     private fun setUiRefreshing(refreshing: Boolean) {
+//        Log.d("ListViewModel", "set refreshing: " + refreshing)
         refreshLayout?.post {
+//            Log.d("ListViewModel", "set refreshing done")
             refreshLayout?.isRefreshing = refreshing
         }
     }

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/ListViewModel.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/ListViewModel.kt
@@ -2,7 +2,6 @@ package com.duyp.architecture.clean.android.powergit.ui.base
 
 import android.support.annotation.MainThread
 import android.support.v7.util.DiffUtil
-import android.util.Log
 import com.duyp.architecture.clean.android.powergit.domain.entities.ListEntity
 import com.duyp.architecture.clean.android.powergit.domain.entities.exception.AuthenticationException
 import com.duyp.architecture.clean.android.powergit.printStacktraceIfDebug
@@ -76,7 +75,6 @@ abstract class ListViewModel<S, I: ListIntent, EntityType, ListType>: BaseViewMo
                     .filter { !mIsLoading && mListEntity.canLoadMore() }
                     .observeOn(AndroidSchedulers.mainThread())
                     .doOnNext {
-                        Log.d("LoadMoreTest", "Loading more on " + Thread.currentThread())
                         setListState { copy(loadingMore = Event.empty()) }
                     }
                     .switchMap { loadData(false) }
@@ -225,7 +223,6 @@ abstract class ListViewModel<S, I: ListIntent, EntityType, ListType>: BaseViewMo
                     val diffResult = calculateDiffResult(it)
                     mListEntity = it
                     val err = mListEntity.apiError?.message ?: ""
-                    Log.d("ListViewModel", "OnNext on " + Thread.currentThread())
                     setListState {
                         copy(
                                 showOfflineNotice = mListEntity.isOfflineData,
@@ -253,7 +250,6 @@ abstract class ListViewModel<S, I: ListIntent, EntityType, ListType>: BaseViewMo
                     }
                 }
                 .doOnComplete {
-                    Log.d("ListViewModel", "Load completed! on " + Thread.currentThread())
                     mIsLoading = false
                     setListState {
                         copy(

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/ListViewModel.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/ListViewModel.kt
@@ -76,7 +76,7 @@ abstract class ListViewModel<S, I: ListIntent, EntityType, ListType>: BaseViewMo
                     .filter { !mIsLoading && mListEntity.canLoadMore() }
                     .observeOn(AndroidSchedulers.mainThread())
                     .doOnNext {
-                        Log.d("ListViewModel", "Loading more on " + Thread.currentThread())
+                        Log.d("LoadMoreTest", "Loading more on " + Thread.currentThread())
                         setListState { copy(loadingMore = Event.empty()) }
                     }
                     .switchMap { loadData(false) }
@@ -144,7 +144,7 @@ abstract class ListViewModel<S, I: ListIntent, EntityType, ListType>: BaseViewMo
     @MainThread
     protected fun clearResults() {
         setListState {
-            copy(refreshable = checkRefreshable(), loadCompleted = Event(calculateDiffResult(ListEntity())))
+            copy(refreshable = checkRefreshable(), dataUpdated = Event(calculateDiffResult(ListEntity())))
         }
         mLoadDisposable?.dispose()
         mListEntity = ListEntity()
@@ -229,7 +229,7 @@ abstract class ListViewModel<S, I: ListIntent, EntityType, ListType>: BaseViewMo
                     setListState {
                         copy(
                                 showOfflineNotice = mListEntity.isOfflineData,
-                                loadCompleted = Event(diffResult),
+                                dataUpdated = Event(diffResult),
                                 errorMessage = if (err.isEmpty()) null else Event(err)
                         )
                     }
@@ -259,7 +259,8 @@ abstract class ListViewModel<S, I: ListIntent, EntityType, ListType>: BaseViewMo
                         copy(
                                 showLoading = false,
                                 showEmptyView = getTotalCount() == 0,
-                                refreshable = checkRefreshable()
+                                refreshable = checkRefreshable(),
+                                loadCompleted = Event.empty()
                         )
                     }
                 }
@@ -277,7 +278,8 @@ data class ListState(
         val refresh: Event<Unit>? = null,
         val errorMessage: Event<String>? = null,
         val loadingMore: Event<Unit>? = null,
-        val loadCompleted: Event<DiffUtil.DiffResult>? = null
+        val loadCompleted: Event<Unit>? = null,
+        val dataUpdated: Event<DiffUtil.DiffResult>? = null
 )
 
 interface ListIntent {

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/adapter/LoadMoreAdapter.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/adapter/LoadMoreAdapter.kt
@@ -1,7 +1,6 @@
 package com.duyp.architecture.clean.android.powergit.ui.base.adapter
 
 import android.support.v7.widget.RecyclerView
-import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import com.duyp.architecture.clean.android.powergit.R
@@ -11,7 +10,6 @@ abstract class LoadMoreAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>()
 
     companion object {
         private const val TYPE_PROGRESS = 333
-        private const val TYPE_ITEM = 10
     }
 
     private var mIsProgressAdded = false
@@ -40,10 +38,10 @@ abstract class LoadMoreAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>()
     }
 
     fun addProgress() {
-        Log.d("ProgressAdapter", "Adding progress (mIsProgressAdded = $mIsProgressAdded)")
         if (!mIsProgressAdded) {
             mIsProgressAdded = true
-            notifyItemInserted(itemCount)
+//            notifyItemInserted(itemCount -1)
+            notifyDataSetChanged()
         }
     }
 

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/adapter/LoadMoreAdapter.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/adapter/LoadMoreAdapter.kt
@@ -40,13 +40,15 @@ abstract class LoadMoreAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>()
     fun addProgress() {
         if (!mIsProgressAdded) {
             mIsProgressAdded = true
-//            notifyItemInserted(itemCount -1)
-            notifyDataSetChanged()
+            notifyItemInserted(itemCount -1)
         }
     }
 
     fun removeProgress() {
-        mIsProgressAdded = false
+        if (mIsProgressAdded) {
+            mIsProgressAdded = false
+            notifyItemRemoved(itemCount)
+        }
     }
 
     abstract fun getTotalItem(): Int

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/drawer/DrawerViewModel.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/drawer/DrawerViewModel.kt
@@ -7,6 +7,7 @@ import com.duyp.architecture.clean.android.powergit.ui.Event
 import com.duyp.architecture.clean.android.powergit.ui.base.BaseViewModel
 import io.reactivex.Flowable
 import io.reactivex.Observable
+import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 
@@ -21,9 +22,10 @@ class DrawerViewModel @Inject constructor(
 
         addDisposable {
             intentSubject.ofType(DrawerIntent.RefreshUser::class.java)
-                    .subscribeOn(Schedulers.io())
+                    .observeOn(Schedulers.io())
                     .switchMap {
                         mGetUser.getCurrentLoggedInUser()
+                                .observeOn(AndroidSchedulers.mainThread())
                                 .doOnNext { user ->
                                     setState { copy(user = user) }
                                 }
@@ -38,10 +40,11 @@ class DrawerViewModel @Inject constructor(
 
         addDisposable {
             intentSubject.ofType(DrawerIntent.LogoutIntent::class.java)
-                    .subscribeOn(Schedulers.io())
+                    .observeOn(Schedulers.io())
                     .switchMapCompletable {
                         mLogoutUser.logoutCurrentUser()
                                 .onErrorComplete()
+                                .observeOn(AndroidSchedulers.mainThread())
                                 .doOnComplete {
                                     setState { copy(refreshUser = Event(Unit)) }
                                 }
@@ -51,10 +54,11 @@ class DrawerViewModel @Inject constructor(
 
         addDisposable {
             intentSubject.ofType(DrawerIntent.OpenUserProfile::class.java)
-                    .subscribeOn(Schedulers.io())
+                    .observeOn(Schedulers.io())
                     .switchMapSingle {
                         mGetUser.getCurrentLoggedInUsername()
                                 .onErrorReturnItem("")
+                                .observeOn(AndroidSchedulers.mainThread())
                                 .doOnSuccess { username ->
                                     if (username.isEmpty()) {
                                         setState { copy(navigation = Event(DrawerNavigation.LOGIN)) }

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/login/LoginActivity.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/login/LoginActivity.kt
@@ -28,6 +28,7 @@ class LoginActivity : ViewModelActivity<LoginViewState, LoginIntent, LoginViewMo
             setLoading(isLoading)
             event(errorMessage) {
                 showToastMessage(this)
+                showKeyboard(edtPassword)
             }
             event(loginSuccess) {
                 showToastMessage("login success!")
@@ -55,6 +56,9 @@ class LoginActivity : ViewModelActivity<LoginViewState, LoginIntent, LoginViewMo
     private fun setLoading(isLoading: Boolean) {
         btnLogin.visibility = if (!isLoading) View.VISIBLE else View.GONE
         progress.visibility = if (isLoading) View.VISIBLE else View.GONE
+        if (isLoading) {
+            hideKeyboard()
+        }
     }
 
     private fun navigateMain() {

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/search/SearchViewModel.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/search/SearchViewModel.kt
@@ -41,7 +41,7 @@ class SearchViewModel @Inject constructor(
 
     override fun getLoadMoreIntent() = SearchRepoIntent.LoadMore
 
-    override fun initState() = ListState(refreshable = false)
+    override fun initState() = ListState()
 
     override fun getItem(listItem: SearchItem) = listItem
 
@@ -50,7 +50,7 @@ class SearchViewModel @Inject constructor(
     override fun composeIntent(intentSubject: Observable<SearchRepoIntent>) {
         super.composeIntent(intentSubject)
 
-        setState { this }
+        setState { copy(refreshable = false) }
 
         addDisposable {
             intentSubject.ofType(SearchRepoIntent.Search::class.java)
@@ -69,7 +69,8 @@ class SearchViewModel @Inject constructor(
     }
 
     override fun checkRefreshable(): Boolean {
-        return !mSearchTerm.isEmpty()
+        //return !mSearchTerm.isEmpty()
+        return false
     }
 
     override fun loadList(currentList: ListEntity<SearchItem>): Observable<ListEntity<SearchItem>> {

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/widgets/recyclerview/layout_manager/LinearManager.java
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/widgets/recyclerview/layout_manager/LinearManager.java
@@ -22,6 +22,10 @@ public class LinearManager extends LinearLayoutManager {
         super(context, attrs, defStyleAttr, defStyleRes);
     }
 
+    @Override public boolean supportsPredictiveItemAnimations() {
+        return false;
+    }
+
     @Override public void onLayoutChildren(RecyclerView.Recycler recycler, RecyclerView.State state) {
         try {
             super.onLayoutChildren(recycler, state);

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/widgets/recyclerview/scroll/InfiniteScroller.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/widgets/recyclerview/scroll/InfiniteScroller.kt
@@ -19,7 +19,10 @@ class InfiniteScroller(
 
     private var mIsNewlyAdded = true
 
+    private var mRecyclerView: RecyclerView? = null
+
     override fun onScrolled(recyclerView: RecyclerView?, dx: Int, dy: Int) {
+        mRecyclerView = recyclerView
         if (mIsNewlyAdded) {
             mIsNewlyAdded = false
             return
@@ -52,12 +55,16 @@ class InfiniteScroller(
 
     fun reset() {
         mLoading = false
-        mAdapter.removeProgress()
+        mRecyclerView?.post {
+            mAdapter.removeProgress()
+        }
     }
 
     fun setLoading() {
         mLoading = true
-        mAdapter.addProgress()
+        mRecyclerView?.post {
+            mAdapter.addProgress()
+        }
     }
 
     private fun initLayoutManager(layoutManager: RecyclerView.LayoutManager) {

--- a/app/src/main/res/layout/item_section_header.xml
+++ b/app/src/main/res/layout/item_section_header.xml
@@ -5,7 +5,7 @@
           style="@style/TextAppearanceTitle"
           android:orientation="vertical"
           android:layout_width="match_parent"
-          android:layout_height="@dimen/x_large"
+          android:layout_height="wrap_content"
           android:gravity="center_vertical"
           android:padding="@dimen/small"
           android:textColor="?colorAccent"

--- a/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/usecases/repo/GetRecentRepos.kt
+++ b/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/usecases/repo/GetRecentRepos.kt
@@ -1,0 +1,14 @@
+package com.duyp.architecture.clean.android.powergit.domain.usecases.repo
+
+import com.duyp.architecture.clean.android.powergit.domain.repositories.RecentRepoRepository
+import io.reactivex.Single
+import javax.inject.Inject
+
+class GetRecentRepos @Inject constructor(
+        private val mRecentRepoRepository: RecentRepoRepository
+) {
+
+    fun search(term: String): Single<List<Long>> =
+            mRecentRepoRepository.getRecentRepoIds(term)
+                    .onErrorReturnItem(emptyList())
+}

--- a/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/usecases/repo/SearchPublicRepo.kt
+++ b/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/usecases/repo/SearchPublicRepo.kt
@@ -1,0 +1,16 @@
+package com.duyp.architecture.clean.android.powergit.domain.usecases.repo
+
+import com.duyp.architecture.clean.android.powergit.domain.entities.ListEntity
+import com.duyp.architecture.clean.android.powergit.domain.entities.mergeWithPreviousPage
+import com.duyp.architecture.clean.android.powergit.domain.entities.repo.RepoEntity
+import com.duyp.architecture.clean.android.powergit.domain.repositories.SearchRepository
+import javax.inject.Inject
+
+class SearchPublicRepo @Inject constructor(
+        private val mSearchRepository: SearchRepository
+) {
+
+    fun search(previousList: ListEntity<RepoEntity>, term: String) =
+            mSearchRepository.searchRepos(term, previousList.getNextPage())
+                    .mergeWithPreviousPage(previousList)
+}


### PR DESCRIPTION
- No longer allow set view state on background thread: now uses `setValue` instead of `postValue`
- Fix `LoadMoreAdapter` and `InfiniteScroller` cause crash in RecyclerView
- Fix state conflicts in` ListViewModel` by adding more in ListState: `DataChanged(DiffResult)` and `LoadCompleted`