### PR TITLE
Check accounts at startup

### DIFF
--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/splash/SplashViewModel.kt
@@ -4,6 +4,8 @@ import com.duyp.architecture.clean.android.powergit.domain.usecases.CheckUser
 import com.duyp.architecture.clean.android.powergit.ui.Event
 import com.duyp.architecture.clean.android.powergit.ui.base.BaseViewModel
 import io.reactivex.Observable
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 
 class SplashViewModel @Inject constructor(
@@ -12,8 +14,10 @@ class SplashViewModel @Inject constructor(
 
     override fun composeIntent(intentSubject: Observable<Any>) {
            addDisposable {
-               mCheckUser.hasLoggedInUser()
+               mCheckUser.checkCurrentUser()
+                       .subscribeOn(Schedulers.io())
                        .onErrorReturnItem(false)
+                       .observeOn(AndroidSchedulers.mainThread())
                        .subscribe { hasLoggedInUser ->
                            if (hasLoggedInUser)
                                setState { copy(navigation = Event(Navigation.MAIN)) }

--- a/data/src/main/java/com/duyp/architecture/clean/android/powergit/data/database/UserDao.kt
+++ b/data/src/main/java/com/duyp/architecture/clean/android/powergit/data/database/UserDao.kt
@@ -4,6 +4,7 @@ import android.arch.persistence.room.Dao
 import android.arch.persistence.room.Query
 import com.duyp.architecture.clean.android.powergit.data.entities.user.UserLocalData
 import io.reactivex.Flowable
+import io.reactivex.Maybe
 
 @Dao
 abstract class UserDao : BaseDao<UserLocalData>() {
@@ -11,5 +12,6 @@ abstract class UserDao : BaseDao<UserLocalData>() {
     @Query("SELECT * FROM User WHERE login = :username")
     abstract fun getUser(username: String) : Flowable<UserLocalData>
 
-
+    @Query("SELECT * FROM User WHERE id = :id")
+    abstract fun getUserMaybe(id: Long) : Maybe<UserLocalData>
 }

--- a/data/src/main/java/com/duyp/architecture/clean/android/powergit/data/repositories/AuthenticationRepositoryImpl.kt
+++ b/data/src/main/java/com/duyp/architecture/clean/android/powergit/data/repositories/AuthenticationRepositoryImpl.kt
@@ -1,8 +1,10 @@
 package com.duyp.architecture.clean.android.powergit.data.repositories
 
 import com.duyp.architecture.clean.android.powergit.data.utils.AccountManagerHelper
+import com.duyp.architecture.clean.android.powergit.domain.entities.AuthenticationEntity
 import com.duyp.architecture.clean.android.powergit.domain.repositories.AuthenticationRepository
 import io.reactivex.Maybe
+import io.reactivex.Observable
 import io.reactivex.Single
 import javax.inject.Inject
 
@@ -15,6 +17,19 @@ class AuthenticationRepositoryImpl @Inject constructor(
                 .map { it.toList() }
                 .flattenAsObservable { it }
                 .map { it.name }
+                .toList()
+    }
+
+    override fun getAuthenticatedAccounts(): Single<List<AuthenticationEntity>> {
+        return Observable.fromIterable(mAccountManagerHelper.getAllAccounts().asIterable())
+                .map {
+                    AuthenticationEntity (
+                            username = it.name,
+                            password = mAccountManagerHelper.getPassword(it.name) ?: "",
+                            token = mAccountManagerHelper.getAuth(it.name) ?: ""
+                    )
+                }
+                .filter { it.password.isNotEmpty() && it.token.isNotEmpty() }
                 .toList()
     }
 

--- a/data/src/main/java/com/duyp/architecture/clean/android/powergit/data/repositories/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/duyp/architecture/clean/android/powergit/data/repositories/UserRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.duyp.architecture.clean.android.powergit.domain.entities.UserEntity
 import com.duyp.architecture.clean.android.powergit.domain.repositories.UserRepository
 import io.reactivex.Completable
 import io.reactivex.Flowable
+import io.reactivex.Maybe
 import io.reactivex.Single
 import javax.inject.Inject
 
@@ -38,4 +39,8 @@ class UserRepositoryImpl @Inject constructor(
                 .map { mUserLocalToEntityMapper.mapFrom(it) }
     }
 
+    override fun getUserById(id: Long): Maybe<UserEntity> {
+        return mUserDao.getUserMaybe(id)
+                .map { mUserLocalToEntityMapper.mapFrom(it) }
+    }
 }

--- a/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/entities/AuthenticationEntity.kt
+++ b/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/entities/AuthenticationEntity.kt
@@ -1,0 +1,7 @@
+package com.duyp.architecture.clean.android.powergit.domain.entities
+
+data class AuthenticationEntity(
+        var username: String,
+        var password: String,
+        var token: String
+)

--- a/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/repositories/AuthenticationRepository.kt
+++ b/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/repositories/AuthenticationRepository.kt
@@ -1,5 +1,6 @@
 package com.duyp.architecture.clean.android.powergit.domain.repositories
 
+import com.duyp.architecture.clean.android.powergit.domain.entities.AuthenticationEntity
 import io.reactivex.Single
 
 interface AuthenticationRepository {
@@ -9,6 +10,8 @@ interface AuthenticationRepository {
      * @return list of account's username
      */
     fun getAllAccounts() : Single<List<String>>
+
+    fun getAuthenticatedAccounts(): Single<List<AuthenticationEntity>>
 
     /**
      * Get authentication token of given username

--- a/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/repositories/UserRepository.kt
+++ b/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/repositories/UserRepository.kt
@@ -3,6 +3,7 @@ package com.duyp.architecture.clean.android.powergit.domain.repositories
 import com.duyp.architecture.clean.android.powergit.domain.entities.UserEntity
 import io.reactivex.Completable
 import io.reactivex.Flowable
+import io.reactivex.Maybe
 import io.reactivex.Single
 
 interface UserRepository {
@@ -25,4 +26,11 @@ interface UserRepository {
      * @return Flowable emitting user entity whenever user's data changed
      */
     fun getUser(username: String) : Flowable<UserEntity>
+
+    /**
+     * Get [Maybe] of an user by given [id]
+     *
+     * @return complete if no user
+     */
+    fun getUserById(id: Long): Maybe<UserEntity>
 }

--- a/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/usecases/CheckUser.kt
+++ b/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/usecases/CheckUser.kt
@@ -2,12 +2,14 @@ package com.duyp.architecture.clean.android.powergit.domain.usecases
 
 import com.duyp.architecture.clean.android.powergit.domain.repositories.AuthenticationRepository
 import com.duyp.architecture.clean.android.powergit.domain.repositories.SettingRepository
+import io.reactivex.Completable
 import io.reactivex.Single
 import javax.inject.Inject
 
 class CheckUser @Inject constructor(
         private val mAuthenticationRepository: AuthenticationRepository,
-        private val mSettingRepository: SettingRepository
+        private val mSettingRepository: SettingRepository,
+        private val mLoginUser: LoginUser
 ) {
 
     /**
@@ -29,5 +31,38 @@ class CheckUser @Inject constructor(
             Single.fromCallable { mSettingRepository.getCurrentUsername() }
                     .flatMap { isLoggedIn(it) }
                     .onErrorReturnItem(false)
+
+    /**
+     * Check for current logged in user. If we don't have any current logged user stored in our app, the account
+     * manager will be checked instead (the case user clear app data but didn't clear accounts in account settings).
+     * In this case if we have any account which has password and authentication, it will be logged in automatically
+     * view [LoginUser] to verify the user's password haven't been changed in server side as well as getting user
+     * info and store it in our database
+     *
+     * @return Single emitting true if has logged in user, otherwise false
+     */
+    fun checkCurrentUser(): Single<Boolean> {
+        return hasLoggedInUser()
+                .flatMap {
+                    if (it) {
+                        Single.just(true)
+                    } else {
+                        mAuthenticationRepository.getAuthenticatedAccounts()
+                                .flatMap { accounts ->
+                                    if (accounts.isEmpty()) {
+                                        Single.just(false)
+                                    } else {
+                                        Completable.fromAction {
+                                            mSettingRepository.setLastLoggedInUsername(accounts[0].username)
+                                        }
+                                                .andThen(mLoginUser.login(accounts[0].username, accounts[0].password))
+                                                .andThen(Single.just(true))
+                                                .onErrorReturnItem(false)
+                                    }
+                                }
+
+                    }
+                }
+    }
 
 }

--- a/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/usecases/GetUser.kt
+++ b/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/usecases/GetUser.kt
@@ -3,16 +3,13 @@ package com.duyp.architecture.clean.android.powergit.domain.usecases
 import com.duyp.architecture.clean.android.powergit.domain.entities.Optional
 import com.duyp.architecture.clean.android.powergit.domain.entities.UserEntity
 import com.duyp.architecture.clean.android.powergit.domain.entities.exception.AuthenticationException
-import com.duyp.architecture.clean.android.powergit.domain.repositories.AuthenticationRepository
 import com.duyp.architecture.clean.android.powergit.domain.repositories.SettingRepository
 import com.duyp.architecture.clean.android.powergit.domain.repositories.UserRepository
-import com.duyp.architecture.clean.android.powergit.domain.utils.CommonUtil
 import io.reactivex.Flowable
 import io.reactivex.Single
 import javax.inject.Inject
 
 class GetUser @Inject constructor(
-        private val mAuthenticationRepository: AuthenticationRepository,
         private val mCheckUser: CheckUser,
         private val mSettingRepository: SettingRepository,
         private val mUserRepository: UserRepository
@@ -54,20 +51,12 @@ class GetUser @Inject constructor(
      */
     fun getLastLoggedInUsername() = mSettingRepository.getLastLoggedInUsername()
 
-    fun getUser(id: Long): Single<Optional<UserEntity>> = Single.just(Optional.empty())
-
     /**
-     * Get all users in account manager which have authentication saved. This is used for checking if we have some
-     * users saved in account managers but don't have any indicator in the app about their existing (in case of
-     * user cleared app data)
-     *
-     * @return all username
+     * Get an [Optional] of [UserEntity] by given user id
      */
-    fun getAuthenticatedUsersInAccountManager(): Single<List<String>> =
-            mAuthenticationRepository.getAllAccounts()
-                    .flattenAsObservable { it }
-                    // only get authenticated users (have token saved)
-                    .filter { !CommonUtil.isEmpty(it, mAuthenticationRepository.getAuthentication(it)) }
-                    .toList()
-                    .onErrorReturnItem(emptyList())
+    fun getUser(id: Long): Single<Optional<UserEntity>> =
+            mUserRepository.getUserById(id)
+                    .map { Optional.of(it) }
+                    .toSingle(Optional.empty())
+                    .onErrorReturnItem(Optional.empty())
 }

--- a/domain/src/test/java/com/duyp/architecture/clean/android/powergit/domain/entities/issue/IssueQueryProviderTest.kt
+++ b/domain/src/test/java/com/duyp/architecture/clean/android/powergit/domain/entities/issue/IssueQueryProviderTest.kt
@@ -1,6 +1,7 @@
 package com.duyp.architecture.clean.android.powergit.domain.entities.issue
 
 import com.duyp.architecture.clean.android.powergit.domain.assertEquals
+import com.duyp.architecture.clean.android.powergit.domain.entities.type.IssueState
 import org.junit.Test
 
 class IssueQueryProviderTest {
@@ -8,30 +9,35 @@ class IssueQueryProviderTest {
     @Test
     fun getIssueQueryTest() {
         IssueQueryProvider.getIssuesQuery("duyp", "clean-architecture", IssueState.CLOSED)
+                .toString()
                 .assertEquals("+type:issue+repo:duyp/clean-architecture+is:closed")
     }
 
     @Test
     fun getMyIssueQueryTest() {
         IssueQueryProvider.getMyIssuesQuery("duyp", IssueState.OPEN)
+                .toString()
                 .assertEquals("+type:issue+author:duyp+is:open")
     }
 
     @Test
     fun getAssignedIssueQueryTest() {
         IssueQueryProvider.getAssignedIssuesQuery("duyp", IssueState.ALL)
+                .toString()
                 .assertEquals("+type:issue+assignee:duyp+is:all")
     }
 
     @Test
     fun getMentionedIssueQueryTest() {
         IssueQueryProvider.getMentionedIssuesQuery("duyp", IssueState.OPEN)
+                .toString()
                 .assertEquals("+type:issue+mentions:duyp+is:open")
     }
 
     @Test
     fun getParticipatedIssueQueryTest() {
         IssueQueryProvider.getParticipatedIssuesQuery("duyp", IssueState.ALL)
+                .toString()
                 .assertEquals("+type:issue+involves:duyp+is:all")
     }
 }

--- a/domain/src/test/java/com/duyp/architecture/clean/android/powergit/domain/entities/pullrequest/PullRequestQueryProviderTest.kt
+++ b/domain/src/test/java/com/duyp/architecture/clean/android/powergit/domain/entities/pullrequest/PullRequestQueryProviderTest.kt
@@ -14,36 +14,42 @@ class PullRequestQueryProviderTest {
     @Test
     fun getPullRequestQueryTest() {
         getPullRequestQuery("duyp", "clean-architecture", PullRequestState.CLOSED)
+                .toString()
                 .assertEquals("+type:pr+repo:duyp/clean-architecture+is:closed")
     }
 
     @Test
     fun getMyPullRequestQueryTest() {
         getMyPullRequestQuery("duyp", PullRequestState.OPEN)
+                .toString()
                 .assertEquals("+type:pr+author:duyp+is:open")
     }
 
     @Test
     fun getAssignedPullRequestQueryTest() {
         getAssignedPullRequestQuery("duyp", PullRequestState.ALL)
+                .toString()
                 .assertEquals("+type:pr+assignee:duyp+is:all")
     }
 
     @Test
     fun getMentionedPullRequestQueryTest() {
         getMentionedPullRequestQuery("duyp", PullRequestState.OPEN)
+                .toString()
                 .assertEquals("+type:pr+mentions:duyp+is:open")
     }
 
     @Test
     fun getReviewRequestsPullRequestQueryTest() {
         getReviewRequestedPullRequestQuery("duyp", PullRequestState.OPEN)
+                .toString()
                 .assertEquals("+type:pr+review-requested:duyp+is:open")
     }
 
     @Test
     fun getParticipatedPullRequestQueryTest() {
         getParticipatedPullRequestQuery("duyp", PullRequestState.ALL)
+                .toString()
                 .assertEquals("+type:pr+involves:duyp+is:all")
     }
 }

--- a/domain/src/test/java/com/duyp/architecture/clean/android/powergit/domain/usecases/CheckUserTest.kt
+++ b/domain/src/test/java/com/duyp/architecture/clean/android/powergit/domain/usecases/CheckUserTest.kt
@@ -1,23 +1,30 @@
 package com.duyp.architecture.clean.android.powergit.domain.usecases
 
+import com.duyp.architecture.clean.android.powergit.domain.entities.AuthenticationEntity
+import com.duyp.architecture.clean.android.powergit.domain.entities.exception.AuthenticationException
 import com.duyp.architecture.clean.android.powergit.domain.repositories.AuthenticationRepository
 import com.duyp.architecture.clean.android.powergit.domain.repositories.SettingRepository
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
+import io.reactivex.Completable
+import io.reactivex.Single
 import org.junit.Test
+import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
 
 class CheckUserTest : UseCaseTest<CheckUser>() {
 
-    @Mock
-    private lateinit var mAuthenticationRepository: AuthenticationRepository
+    @Mock private lateinit var mAuthenticationRepository: AuthenticationRepository
 
-    @Mock lateinit var mSettingRepository: SettingRepository
+    @Mock private lateinit var mSettingRepository: SettingRepository
+
+    @Mock private lateinit var mLoginUser: LoginUser
 
     override fun createUseCase(): CheckUser {
-        return CheckUser(mAuthenticationRepository, mSettingRepository)
+        return CheckUser(mAuthenticationRepository, mSettingRepository, mLoginUser)
     }
 
     @Test
@@ -66,5 +73,51 @@ class CheckUserTest : UseCaseTest<CheckUser>() {
         mUsecase.hasLoggedInUser()
                 .test()
                 .assertValue { it }
+    }
+
+    @Test
+    fun checkUser_noLoggedInUser_noAuthenticatedAccounts() {
+        whenever(mSettingRepository.getCurrentUsername()).thenReturn(null)
+        whenever(mAuthenticationRepository.getAuthenticatedAccounts()).thenReturn(Single.just(emptyList()))
+
+        mUsecase.checkCurrentUser()
+                .test()
+                .assertValue { !it }
+                .assertComplete()
+
+        verifyZeroInteractions(mLoginUser)
+        verify(mSettingRepository, times(0)).setLastLoggedInUsername(any())
+    }
+
+    @Test
+    fun checkUser_noLoggedInUser_hasAuthenticatedAccounts_loginError() {
+        whenever(mSettingRepository.getCurrentUsername()).thenReturn(null)
+        whenever(mAuthenticationRepository.getAuthenticatedAccounts()).thenReturn(Single.just(listOf(AuthenticationEntity(
+                username = "duyp", password = "1234", token = "abcd"
+        ))))
+        whenever(mLoginUser.login("duyp", "1234")).thenReturn(Completable.error(AuthenticationException()))
+
+        mUsecase.checkCurrentUser()
+                .test()
+                .assertValue { !it }
+                .assertComplete()
+
+        verify(mSettingRepository).setLastLoggedInUsername("duyp")
+    }
+
+    @Test
+    fun checkUser_noLoggedInUser_hasAuthenticatedAccounts_loginSuccess() {
+        whenever(mSettingRepository.getCurrentUsername()).thenReturn(null)
+        whenever(mAuthenticationRepository.getAuthenticatedAccounts()).thenReturn(Single.just(listOf(AuthenticationEntity(
+                username = "duyp1", password = "12345", token = "abcde"
+        ))))
+        whenever(mLoginUser.login("duyp1", "12345")).thenReturn(Completable.complete())
+
+        mUsecase.checkCurrentUser()
+                .test()
+                .assertValue { it }
+                .assertComplete()
+
+        verify(mSettingRepository).setLastLoggedInUsername("duyp1")
     }
 }


### PR DESCRIPTION
Situation: if user clears app data, then current user will be cleared for both user's data and setting value which stores current user name, but in Android account manager the user haven't been removed yet. Therefore if we don't found any current logged in user, we can scan the accounts in which the user and password, authentication token stored, then perform login the account automatically. If the credentials still valid -> process more normally as we have user data stored after logging in successfully, otherwise we ask user to login again and set last logged in username with the account we got from account manager.