### PR TITLE
Remove lazy load support

### DIFF
--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/BasicListFragment.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/BasicListFragment.kt
@@ -14,10 +14,9 @@ import com.duyp.architecture.clean.android.powergit.ui.base.adapter.BaseAdapter
  */
 abstract class BasicListFragment<
         EntityType,
-        ListType,
         A: BaseAdapter<EntityType>,
-        VM: BasicListViewModel<EntityType, ListType>>
-    : ListFragment<EntityType, ListType, A, ListIntent, ListState, VM>() {
+        VM: BasicListViewModel<EntityType>>
+    : ListFragment<EntityType, A, ListIntent, ListState, VM>() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/BasicListViewModel.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/BasicListViewModel.kt
@@ -7,7 +7,7 @@ package com.duyp.architecture.clean.android.powergit.ui.base
  * So basically, the view state is enforced to [ListState] and the view intent is enforced to [ListIntent], other
  * things remain the same in [ListViewModel].
  */
-abstract class BasicListViewModel<EntityType, ListType>: ListViewModel<ListState, ListIntent, EntityType, ListType>() {
+abstract class BasicListViewModel<EntityType>: ListViewModel<ListState, ListIntent, EntityType>() {
 
     override fun initState() = ListState()
 

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/ListFragment.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/base/ListFragment.kt
@@ -29,7 +29,6 @@ import kotlinx.android.synthetic.main.refresh_recycler_view.*
  * is sent to view model and how the view model manage view state of a list
  *
  * @param EntityType type of entity which will be shown in recycler view, is adapter data
- * @param ListType type of data in the [com.duyp.architecture.clean.android.powergit.domain.entities.ListEntity]
  * @param A adapter
  * @param I intent
  * @param S state
@@ -37,11 +36,10 @@ import kotlinx.android.synthetic.main.refresh_recycler_view.*
  */
 abstract class ListFragment<
         EntityType,
-        ListType,
         A: BaseAdapter<EntityType>,
         I: ListIntent,
         S,
-        VM : ListViewModel<S, I, EntityType, ListType>>
+        VM : ListViewModel<S, I, EntityType>>
     : ViewModelFragment<S, I, VM>() {
 
     private lateinit var mAdapter: A

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/event/EventListFragment.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/event/EventListFragment.kt
@@ -9,7 +9,7 @@ import com.duyp.architecture.clean.android.powergit.ui.base.adapter.AdapterData
 import com.duyp.architecture.clean.android.powergit.ui.utils.AvatarLoader
 import javax.inject.Inject
 
-class EventListFragment: BasicListFragment<EventEntity, EventEntity, EventListAdapter, EventViewModel>() {
+class EventListFragment: BasicListFragment<EventEntity, EventListAdapter, EventViewModel>() {
 
     @Inject lateinit var avatarLoader: AvatarLoader
 

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/event/EventViewModel.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/event/EventViewModel.kt
@@ -9,15 +9,13 @@ import javax.inject.Inject
 
 class EventViewModel @Inject constructor(
         private val mGetUserEventList: GetUserEventList
-): BasicListViewModel<EventEntity, EventEntity>() {
+): BasicListViewModel<EventEntity>() {
 
     var username: String? = null
 
     var type: EventType? = EventType.SELF
 
     override fun refreshAtStartup() = true
-
-    override fun getItem(listItem: EventEntity) = listItem
 
     override fun loadList(currentList: ListEntity<EventEntity>): Observable<ListEntity<EventEntity>> {
         val isReceivedEvents = type == EventType.RECEIVED
@@ -28,7 +26,7 @@ class EventViewModel @Inject constructor(
         }
     }
 
-    override fun areItemEquals(old: EventEntity, new: EventEntity): Boolean {
+    override fun areItemsTheSame(old: EventEntity, new: EventEntity): Boolean {
         return old.id == new.id
     }
 }

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/issue/list/IssueListFragment.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/issue/list/IssueListFragment.kt
@@ -17,7 +17,7 @@ import com.duyp.architecture.clean.android.powergit.ui.utils.AvatarLoader
 import kotlinx.android.synthetic.main.fragment_user_issue_list.*
 import javax.inject.Inject
 
-class IssueListFragment: ListFragment<IssueEntity, Long, IssueAdapter, IssueListIntent, IssueListState,
+class IssueListFragment: ListFragment<IssueEntity, IssueAdapter, IssueListIntent, IssueListState,
         IssueListViewModel>() {
 
     @Inject internal lateinit var mAvatarLoader: AvatarLoader

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/issue/list/IssueListViewModel.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/issue/list/IssueListViewModel.kt
@@ -5,7 +5,6 @@ import com.duyp.architecture.clean.android.powergit.domain.entities.IssueEntity
 import com.duyp.architecture.clean.android.powergit.domain.entities.ListEntity
 import com.duyp.architecture.clean.android.powergit.domain.entities.issue.MyIssueTypeEntity
 import com.duyp.architecture.clean.android.powergit.domain.entities.type.IssueState
-import com.duyp.architecture.clean.android.powergit.domain.usecases.issue.GetIssue
 import com.duyp.architecture.clean.android.powergit.domain.usecases.issue.GetIssueList
 import com.duyp.architecture.clean.android.powergit.ui.base.ListIntent
 import com.duyp.architecture.clean.android.powergit.ui.base.ListState
@@ -16,9 +15,8 @@ import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 
 class IssueListViewModel @Inject constructor(
-        private val mGetIssueList: GetIssueList,
-        private val mGetIssue: GetIssue
-): ListViewModel<IssueListState, IssueListIntent, IssueEntity, Long>() {
+        private val mGetIssueList: GetIssueList
+): ListViewModel<IssueListState, IssueListIntent, IssueEntity>() {
 
     internal lateinit var listType: IssueListType
 
@@ -29,11 +27,6 @@ class IssueListViewModel @Inject constructor(
 
     // for user's issue list
     private var mUserName: String? = null
-
-    override fun getItem(listItem: Long) = mGetIssue.get(listItem)
-            .subscribeOn(Schedulers.io())
-            .blockingGet()
-            .orElse(null)!!
 
     override fun refreshAtStartup() = true
 
@@ -77,7 +70,7 @@ class IssueListViewModel @Inject constructor(
         }
     }
 
-    override fun loadList(currentList: ListEntity<Long>): Observable<ListEntity<Long>> {
+    override fun loadList(currentList: ListEntity<IssueEntity>): Observable<ListEntity<IssueEntity>> {
         return withState {
             val issueState = if (isOpenIssue) IssueState.OPEN else IssueState.CLOSED
             return@withState if (listType == IssueListType.USER_ISSUES)
@@ -91,7 +84,7 @@ class IssueListViewModel @Inject constructor(
         }
     }
 
-    override fun areItemEquals(old: Long, new: Long) = old == new
+    override fun areItemsTheSame(old: IssueEntity, new: IssueEntity) = old == new
 
     override fun getRefreshIntent() = IssueListIntent.Refresh
 

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/repo/list/RepoListFragment.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/repo/list/RepoListFragment.kt
@@ -8,7 +8,7 @@ import com.duyp.architecture.clean.android.powergit.ui.base.adapter.AdapterData
 import com.duyp.architecture.clean.android.powergit.ui.utils.AvatarLoader
 import javax.inject.Inject
 
-class RepoListFragment: BasicListFragment<RepoEntity, Long, RepoListAdapter, RepoListViewModel>() {
+class RepoListFragment: BasicListFragment<RepoEntity, RepoListAdapter, RepoListViewModel>() {
 
     @Inject lateinit var mAvatarLoader: AvatarLoader
 

--- a/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/repo/list/RepoListViewModel.kt
+++ b/app/src/main/java/com/duyp/architecture/clean/android/powergit/ui/features/repo/list/RepoListViewModel.kt
@@ -3,18 +3,15 @@ package com.duyp.architecture.clean.android.powergit.ui.features.repo.list
 import com.duyp.architecture.clean.android.powergit.domain.entities.FilterOptions
 import com.duyp.architecture.clean.android.powergit.domain.entities.ListEntity
 import com.duyp.architecture.clean.android.powergit.domain.entities.repo.RepoEntity
-import com.duyp.architecture.clean.android.powergit.domain.usecases.repo.GetRepo
 import com.duyp.architecture.clean.android.powergit.domain.usecases.repo.GetUserRepoList
 import com.duyp.architecture.clean.android.powergit.ui.base.BasicListViewModel
 import com.duyp.architecture.clean.android.powergit.ui.base.adapter.AdapterData
 import io.reactivex.Observable
-import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 
 class RepoListViewModel @Inject constructor(
-        private val mGetUserRepoList: GetUserRepoList,
-        private val mGetRepo: GetRepo
-): BasicListViewModel<RepoEntity, Long>(), AdapterData<RepoEntity> {
+        private val mGetUserRepoList: GetUserRepoList
+): BasicListViewModel<RepoEntity>(), AdapterData<RepoEntity> {
 
     private val mFilterOptions = FilterOptions()
 
@@ -22,21 +19,12 @@ class RepoListViewModel @Inject constructor(
 
     override fun refreshAtStartup() = true
 
-    override fun getItem(listItem: Long): RepoEntity {
-        return mGetRepo.get(listItem)
-                .subscribeOn(Schedulers.io())
-                .blockingGet()
-                .orElse(null)
-    }
-
-    override fun loadList(currentList: ListEntity<Long>): Observable<ListEntity<Long>> {
+    override fun loadList(currentList: ListEntity<RepoEntity>): Observable<ListEntity<RepoEntity>> {
         return if (mUsername != null)
             mGetUserRepoList.getRepoList(currentList, mUsername!!, mFilterOptions).toObservable()
         else
             mGetUserRepoList.getCurrentUserRepoList(currentList, mFilterOptions).toObservable()
     }
 
-    override fun areItemEquals(old: Long, new: Long): Boolean {
-        return old == new
-    }
+    override fun areItemsTheSame(old: RepoEntity, new: RepoEntity) = old == new
 }

--- a/data/src/main/java/com/duyp/architecture/clean/android/powergit/data/database/IssueDao.kt
+++ b/data/src/main/java/com/duyp/architecture/clean/android/powergit/data/database/IssueDao.kt
@@ -12,14 +12,14 @@ abstract class IssueDao: BaseDao<IssueLocalData>() {
     @Query("SELECT id FROM Issue WHERE title LIKE :searchTerm ORDER BY createdAt DESC")
     abstract fun searchByTitle(searchTerm: String): Single<List<Long>>
 
-    @Query("SELECT id FROM Issue WHERE repoOwner = :repoOwner AND repoName = :repoName AND state = :state ORDER BY createdAt DESC")
-    abstract fun getByRepo(repoOwner: String, repoName: String, state: String?): Single<List<Long>>
+    @Query("SELECT * FROM Issue WHERE repoOwner = :repoOwner AND repoName = :repoName AND state = :state ORDER BY createdAt DESC")
+    abstract fun getByRepo(repoOwner: String, repoName: String, state: String?): Single<List<IssueLocalData>>
 
-    @Query("SELECT id FROM Issue WHERE user_login = :author AND state = :state ORDER BY createdAt DESC")
-    abstract fun getByAuthor(author: String, state: String?): Single<List<Long>>
+    @Query("SELECT * FROM Issue WHERE user_login = :author AND state = :state ORDER BY createdAt DESC")
+    abstract fun getByAuthor(author: String, state: String?): Single<List<IssueLocalData>>
 
-    @Query("SELECT id FROM Issue WHERE assignee_login = :assignee AND state = :state ORDER BY createdAt DESC")
-    abstract fun getByAssignee(assignee: String, state: String?): Single<List<Long>>
+    @Query("SELECT * FROM Issue WHERE assignee_login = :assignee AND state = :state ORDER BY createdAt DESC")
+    abstract fun getByAssignee(assignee: String, state: String?): Single<List<IssueLocalData>>
 
     @Query("SELECT * FROM Issue WHERE id = :id")
     abstract fun getById(id: Long): Maybe<IssueLocalData>

--- a/data/src/main/java/com/duyp/architecture/clean/android/powergit/data/database/RepoDao.kt
+++ b/data/src/main/java/com/duyp/architecture/clean/android/powergit/data/database/RepoDao.kt
@@ -9,8 +9,8 @@ import io.reactivex.Single
 @Dao
 abstract class RepoDao: BaseDao<RepoLocalData>() {
 
-    @Query("SELECT id FROM Repository WHERE owner_login = :username")
-    abstract fun getUserRepoIds(username: String): Single<List<Long>>
+    @Query("SELECT * FROM Repository WHERE owner_login = :username")
+    abstract fun getUserRepos(username: String): Single<List<RepoLocalData>>
 
     @Query("SELECT COUNT(*) FROM Repository WHERE id = :id")
     abstract fun countRepo(id: Long): Int

--- a/data/src/main/java/com/duyp/architecture/clean/android/powergit/data/repositories/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/duyp/architecture/clean/android/powergit/data/repositories/RepoRepositoryImpl.kt
@@ -5,7 +5,7 @@ import com.duyp.architecture.clean.android.powergit.data.database.RepoDao
 import com.duyp.architecture.clean.android.powergit.data.entities.pagination.PageableApiData
 import com.duyp.architecture.clean.android.powergit.data.entities.repo.RepoApiData
 import com.duyp.architecture.clean.android.powergit.data.entities.repo.RepoApiToLocalMapper
-import com.duyp.architecture.clean.android.powergit.data.entities.repo.RepoListApiToIdMapper
+import com.duyp.architecture.clean.android.powergit.data.entities.repo.RepoListApiToEntityMapper
 import com.duyp.architecture.clean.android.powergit.data.entities.repo.RepoLocalToEntityMapper
 import com.duyp.architecture.clean.android.powergit.domain.entities.FilterOptions
 import com.duyp.architecture.clean.android.powergit.domain.entities.ListEntity
@@ -20,20 +20,20 @@ class RepoRepositoryImpl @Inject constructor(
         private val mUserService: UserService
 ) : RepoRepository {
 
-    private val mRepoListApiToIdMapper = RepoListApiToIdMapper()
+    private val mRepoListApiToEntityMapper = RepoListApiToEntityMapper()
 
     private val mRepoApiToLocalMapper = RepoApiToLocalMapper()
 
     private val mRepoLocalToEntityMapper = RepoLocalToEntityMapper()
 
     override fun getUserRepoList(username: String, filterOptions: FilterOptions, page: Int):
-            Single<ListEntity<Long>> {
+            Single<ListEntity<RepoEntity>> {
         return mUserService.getRepos(username, filterOptions.getQueryMap(), page)
                 .processApiRepoList(username, page == ListEntity.STARTING_PAGE)
     }
 
     override fun getMyUserRepoList(username: String, filterOptions: FilterOptions, page: Int):
-            Single<ListEntity<Long>> {
+            Single<ListEntity<RepoEntity>> {
         return mUserService.getMyRepos(filterOptions.getQueryMap(), page)
                 .processApiRepoList(username, page == ListEntity.STARTING_PAGE)
     }
@@ -47,17 +47,18 @@ class RepoRepositoryImpl @Inject constructor(
      * Save repo list api response. Load local data if api error and is first page
      */
     private fun Single<PageableApiData<RepoApiData>>.processApiRepoList(username: String, isStartingPage: Boolean):
-            Single<ListEntity<Long>> {
+            Single<ListEntity<RepoEntity>> {
         return this
                 .doOnSuccess {
                     // save to database
                     mRepoDao.insertList(mRepoApiToLocalMapper.mapFrom(it.items))
                 }
-                .map { mRepoListApiToIdMapper.mapFrom(it) }
+                .map { mRepoListApiToEntityMapper.mapFrom(it) }
                 .onErrorResumeNext { throwable ->
                     if (isStartingPage) {
                         // api error when loading first page, let load from database
-                        return@onErrorResumeNext mRepoDao.getUserRepoIds(username)
+                        return@onErrorResumeNext mRepoDao.getUserRepos(username)
+                                .map { mRepoLocalToEntityMapper.mapFrom(it) }
                                 .map { ListEntity(items = it, isOfflineData = true, apiError = throwable) }
                     } else {
                         return@onErrorResumeNext Single.error(throwable)

--- a/data/src/test/java/com/duyp/architecture/clean/android/powergit/data/repositories/RepoRepositoryImplTest.kt
+++ b/data/src/test/java/com/duyp/architecture/clean/android/powergit/data/repositories/RepoRepositoryImplTest.kt
@@ -32,7 +32,7 @@ class RepoRepositoryImplTest {
     fun getUserRepoList_errorFirstPage_shouldReturnLocalData() {
         whenever(mUserService.getRepos(any(), any(), any()))
                 .thenReturn(Single.error(Exception()))
-        whenever(mRepoDao.getUserRepoIds(any())).thenReturn(Single.just(listOf(1L, 2L, 3L)))
+        whenever(mRepoDao.getUserRepos(any())).thenReturn(Single.just(listOf(1L, 2L, 3L)))
 
         mRepoRepository.getUserRepoList("duyp", FilterOptions(), ListEntity.STARTING_PAGE)
                 .test()
@@ -40,7 +40,7 @@ class RepoRepositoryImplTest {
                     it.items.size == 3 && it.isOfflineData && it.apiError is Exception
                 }
         verify(mUserService).getRepos(eq("duyp"), any(), eq(ListEntity.STARTING_PAGE))
-        verify(mRepoDao).getUserRepoIds("duyp")
+        verify(mRepoDao).getUserRepos("duyp")
     }
 
     @Test
@@ -80,7 +80,7 @@ class RepoRepositoryImplTest {
     fun getMyUserRepoList_errorFirstPage_shouldReturnLocalData() {
         whenever(mUserService.getMyRepos(any(), any()))
                 .thenReturn(Single.error(Exception()))
-        whenever(mRepoDao.getUserRepoIds(any())).thenReturn(Single.just(listOf(1L, 2L, 3L)))
+        whenever(mRepoDao.getUserRepos(any())).thenReturn(Single.just(listOf(1L, 2L, 3L)))
 
         mRepoRepository.getMyUserRepoList("duyp", FilterOptions(), ListEntity.STARTING_PAGE)
                 .test()
@@ -88,7 +88,7 @@ class RepoRepositoryImplTest {
                     it.items.size == 3 && it.isOfflineData && it.apiError is Exception
                 }
         verify(mUserService).getMyRepos(any(), eq(ListEntity.STARTING_PAGE))
-        verify(mRepoDao).getUserRepoIds("duyp")
+        verify(mRepoDao).getUserRepos("duyp")
     }
 
     @Test

--- a/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/repositories/IssueRepository.kt
+++ b/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/repositories/IssueRepository.kt
@@ -13,7 +13,7 @@ interface IssueRepository {
      *
      * See [com.duyp.architecture.clean.android.powergit.domain.entities.issue.IssueQueryProvider]
      */
-    fun getIssueList(query: QueryEntity, page: Int): Single<ListEntity<Long>>
+    fun getIssueList(query: QueryEntity, page: Int): Single<ListEntity<IssueEntity>>
 
     /**
      * Search public issues on github with given [query] and [page]

--- a/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/repositories/RepoRepository.kt
+++ b/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/repositories/RepoRepository.kt
@@ -17,7 +17,7 @@ interface RepoRepository {
      * @param page page number to load
      */
     fun getUserRepoList(username: String, filterOptions: FilterOptions, page: Int):
-            Single<ListEntity<Long>>
+            Single<ListEntity<RepoEntity>>
 
     /**
      * Get repo list (ids) of current user (both public and private since we have credentials) with given filter option
@@ -28,7 +28,7 @@ interface RepoRepository {
      * @param filterOptions option for filtering and sorting
      * @param page page number to load
      */
-    fun getMyUserRepoList(username: String, filterOptions: FilterOptions, page: Int): Single<ListEntity<Long>>
+    fun getMyUserRepoList(username: String, filterOptions: FilterOptions, page: Int): Single<ListEntity<RepoEntity>>
 
     /**
      * Get a repo by given id

--- a/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/usecases/issue/GetIssueList.kt
+++ b/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/usecases/issue/GetIssueList.kt
@@ -1,5 +1,6 @@
 package com.duyp.architecture.clean.android.powergit.domain.usecases.issue
 
+import com.duyp.architecture.clean.android.powergit.domain.entities.IssueEntity
 import com.duyp.architecture.clean.android.powergit.domain.entities.ListEntity
 import com.duyp.architecture.clean.android.powergit.domain.entities.issue.IssueQueryProvider.getIssuesQuery
 import com.duyp.architecture.clean.android.powergit.domain.entities.issue.IssueQueryProvider.getMyIssueQuery
@@ -24,7 +25,7 @@ class GetIssueList @Inject constructor(
      *
      * @return new [ListEntity] which contains all data of [currentList] and new list
      */
-    fun getUserIssues(currentList: ListEntity<Long>, username: String?,
+    fun getUserIssues(currentList: ListEntity<IssueEntity>, username: String?,
                       type: MyIssueTypeEntity, @IssueState state: String) =
             Maybe.fromCallable { username }
                     .switchIfEmpty(mGetUser.getCurrentLoggedInUsername())
@@ -40,7 +41,7 @@ class GetIssueList @Inject constructor(
      *
      * @return new [ListEntity] which contains all data of [currentList] and new list
      */
-    fun getRepoIssues(currentList: ListEntity<Long>, owner: String, repo: String, @IssueState state: String) =
+    fun getRepoIssues(currentList: ListEntity<IssueEntity>, owner: String, repo: String, @IssueState state: String) =
             mIssueRepository.getIssueList(getIssuesQuery(owner, repo, state), currentList.getNextPage())
                     .mergeWithPreviousPage(currentList)
 }

--- a/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/usecases/repo/GetUserRepoList.kt
+++ b/domain/src/main/java/com/duyp/architecture/clean/android/powergit/domain/usecases/repo/GetUserRepoList.kt
@@ -3,6 +3,7 @@ package com.duyp.architecture.clean.android.powergit.domain.usecases.repo
 import com.duyp.architecture.clean.android.powergit.domain.entities.FilterOptions
 import com.duyp.architecture.clean.android.powergit.domain.entities.ListEntity
 import com.duyp.architecture.clean.android.powergit.domain.entities.mergeWithPreviousPage
+import com.duyp.architecture.clean.android.powergit.domain.entities.repo.RepoEntity
 import com.duyp.architecture.clean.android.powergit.domain.repositories.RepoRepository
 import com.duyp.architecture.clean.android.powergit.domain.usecases.GetUser
 import javax.inject.Inject
@@ -21,7 +22,7 @@ class GetUserRepoList @Inject constructor(
      *
      * @return new list appended with previous list, contains all items from starting page to current page
      */
-    fun getRepoList(currentList: ListEntity<Long>, username: String, filterOptions: FilterOptions) =
+    fun getRepoList(currentList: ListEntity<RepoEntity>, username: String, filterOptions: FilterOptions) =
             mRepoRepository.getUserRepoList(username, filterOptions, currentList.getNextPage())
                     .mergeWithPreviousPage(currentList)
 
@@ -35,7 +36,7 @@ class GetUserRepoList @Inject constructor(
      *
      * @return new list appended with previous list, contains all items from starting page to current page
      */
-    fun getCurrentUserRepoList(currentList: ListEntity<Long>, filterOptions: FilterOptions) =
+    fun getCurrentUserRepoList(currentList: ListEntity<RepoEntity>, filterOptions: FilterOptions) =
             mGetUser.getCurrentLoggedInUsername()
                     .flatMap { username ->
                         mRepoRepository.getMyUserRepoList(username, filterOptions, currentList.getNextPage())


### PR DESCRIPTION
As #24, the lazy load mechanism can't live with DiffUtil together since DiffUtil need to compare content of items so the items should be on memory.

Therefore I removed the lazy load support and all items will be load on memory instead. We should also find a better solution for database paging then (such as Paging API of architecture components)